### PR TITLE
Add bytes suffix to fix exponent notation

### DIFF
--- a/charts/vdl/Chart.yaml
+++ b/charts/vdl/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/vdl/templates/statefulset.yaml
+++ b/charts/vdl/templates/statefulset.yaml
@@ -117,6 +117,9 @@ spec:
             - name: NODE_MAX_CACHE_AGE
               value: {{ .Values.core.maxCacheAge | quote }}
             - name: NODE_MAX_CACHE_SIZE
+            # This value needs the bytes suffix removed because of a bug in Helm
+            # where big numbers (even if they are quoted) are automatically converted
+            # to scientific notation. See: https://github.com/helm/helm/issues/1707
               value: {{ .Values.core.maxCacheSize | replace "bytes" "" | quote }}
             - name: NODE_AUX_FLAGS
               value: {{ .Values.core.auxFlags | quote }}

--- a/charts/vdl/templates/statefulset.yaml
+++ b/charts/vdl/templates/statefulset.yaml
@@ -117,7 +117,7 @@ spec:
             - name: NODE_MAX_CACHE_AGE
               value: {{ .Values.core.maxCacheAge | quote }}
             - name: NODE_MAX_CACHE_SIZE
-              value: {{ .Values.core.maxCacheSize | quote }}
+              value: {{ .Values.core.maxCacheSize | replace "bytes" "" | quote }}
             - name: NODE_AUX_FLAGS
               value: {{ .Values.core.auxFlags | quote }}
           livenessProbe:

--- a/charts/vdl/values.yaml
+++ b/charts/vdl/values.yaml
@@ -28,7 +28,7 @@ core:
   logLevel: "debug"
   persistenceMode: "1"
   dynamicConfigMode: "0"
-  maxCacheSize: 1000000000
+  maxCacheSize: "1000000000bytes"
   maxCacheAge: 28800 # 8 hour default
   # legacy properties:
   scriptSignMode: "0"

--- a/charts/vdl/values.yaml
+++ b/charts/vdl/values.yaml
@@ -28,6 +28,9 @@ core:
   logLevel: "debug"
   persistenceMode: "1"
   dynamicConfigMode: "0"
+  # This value needs to be in bytes because of a bug in Helm
+  # that always converts big numbers to scientific notation.
+  # See: https://github.com/helm/helm/issues/1707
   maxCacheSize: "1000000000bytes"
   maxCacheAge: 28800 # 8 hour default
   # legacy properties:


### PR DESCRIPTION
Helm automatically converts big integers to exponent notation. We want to prevent this because we don't accept the scientific notation as argument. Therefore we replace the bytes suffix with nothing so that it will be parsed as a string.