### PR TITLE
Fix CI helm release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,15 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
+      - name: Add repositories
+        run: |
+          for dir in $(ls -d charts/*/); do
+            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          done
+
       - name: Add all dependencies
         run: |
-          helm dependency build
+          helm dependency update charts/vdl
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,10 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
+      - name: Add all dependencies
+        run: |
+          helm dependency build
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:


### PR DESCRIPTION
Add all dependency repos with ugly bash one-liner. Then install the deps with `helm dependency update`.

Based on: 
- https://github.com/helm/chart-releaser-action/issues/74
- https://helm.sh/docs/helm/helm_dependency_build/