### PR TITLE
docker rootless support and bugfixes

### DIFF
--- a/charts/vdl/Chart.yaml
+++ b/charts/vdl/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.2
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/vdl/templates/statefulset.yaml
+++ b/charts/vdl/templates/statefulset.yaml
@@ -77,6 +77,9 @@ spec:
             secretName: {{ .Chart.Name }}-secret-vdl
             defaultMode: 420
             optional: false
+        - name: tmp
+          emptyDir:
+            sizeLimit: 20Mi
         {{- if .Values.loggingEnabled }}
         - name: alloy-config
           configMap:
@@ -107,6 +110,8 @@ spec:
               mountPath: /app/config
             - name: secrets
               mountPath: /app/secrets
+            - name: tmp
+              mountPath: /tmp
           env:
             - name: NODE_NR
               value: {{ .Values.core.nodeNr | quote }}
@@ -236,6 +241,8 @@ spec:
               subPath: web_app.pk
             - name: dynamic-config
               mountPath: /config
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       {{- end }}
       {{- if .Values.healthContainer.enabled }}
         - name: health

--- a/charts/vdl/templates/statefulset.yaml
+++ b/charts/vdl/templates/statefulset.yaml
@@ -46,7 +46,6 @@ spec:
     matchLabels:
       {{- include "vdl.selectorLabels" . | nindent 6 }}
   serviceName: {{ include "vdl.fullname" . }}-n2n
-  # ^ TODO
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -156,6 +155,8 @@ spec:
             # where big numbers (even if they are quoted) are automatically converted
             # to scientific notation. See: https://github.com/helm/helm/issues/1707
               value: {{ .Values.core.maxCacheSize | replace "bytes" "" | quote }}
+            - name: NODE_SECRETS_DIR # per 1.12.3 this setting is the default, but we're configuring it here explicitly for backwards compatability with older images
+              value: /tmp/secrets_run
             - name: NODE_AUX_FLAGS
               value: {{ .Values.core.auxFlags | quote }}
           {{- if not .Values.vpnEnabled }}
@@ -173,8 +174,8 @@ spec:
         {{- if .Values.loggingEnabled }}
         {{- required "A valid VPN setup is required for logging to be enabled" .Values.vpnEnabled }}
         - name: vdl-log-collector
-          image: grafana/alloy:v1.2.1
-          imagePullPolicy: Always
+          image: "{{ .Values.image.logging.repository }}:{{ .Values.image.logging.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: alloy-config
               mountPath: /etc/alloy/config.alloy
@@ -188,7 +189,7 @@ spec:
         {{- end }}
         {{- if .Values.vpnEnabled }}
         - name: openvpn-client
-          image: ghcr.io/wfg/openvpn-client:3.1.0
+          image: "{{ .Values.image.vpn.repository }}:{{ .Values.image.vpn.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: ephemeral
@@ -219,7 +220,8 @@ spec:
       initContainers:
       {{- if .Values.vpnEnabled }}
         - name: vpn-config-setup
-          image: "ghcr.io/rosemanlabs/images/alpine:3.20.1"
+          image: "{{ .Values.image.alpine.repository }}:{{ .Values.image.alpine.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['sh', '-c', "cp /config/client.ovpn /data/vpn/client.ovpn"]
           volumeMounts:
             - name: vpnconfig
@@ -230,7 +232,8 @@ spec:
       {{- if or (eq .Values.core.dynamicConfigMode "1") (eq .Values.core.dynamicConfigMode "true") }}
         # NOTE: this logic may be moved into the main docker image later on
         - name: vdl-config-setup
-          image: apteno/alpine-jq
+          image: "{{ .Values.image.alpineJq.repository }}:{{ .Values.image.alpineJq.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /bin/sh
             - '-xc'
@@ -246,7 +249,8 @@ spec:
       {{- end }}
       {{- if .Values.healthContainer.enabled }}
         - name: health
-          image: "{{ .Values.healthContainer.repository }}:{{ .Values.healthContainer.tag }}"
+          image: "{{ .Values.image.health.repository }}:{{ .Values.image.health.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:
                 name: engine-node-{{ .Values.core.nodeNr }}-envs
@@ -259,7 +263,8 @@ spec:
               mountPath: /app/secrets
       {{- end }}
         - name: vdl-permissions-setup
-          image: apteno/alpine-jq
+          image: "{{ .Values.image.alpineJq.repository }}:{{ .Values.image.alpineJq.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /bin/sh
             - '-xc'

--- a/charts/vdl/templates/statefulset.yaml
+++ b/charts/vdl/templates/statefulset.yaml
@@ -251,6 +251,17 @@ spec:
             - name: secrets
               mountPath: /app/secrets
       {{- end }}
+        - name: vdl-permissions-setup
+          image: apteno/alpine-jq
+          command:
+            - /bin/sh
+            - '-xc'
+            - 'find /app/config /app/data -path "/app/config/lost+found" -prune -o -path "/app/data/lost+found" -prune -o -exec chown 1000:1000 {} +'
+          volumeMounts:
+            - mountPath: /app/data
+              name: persistence
+            - mountPath: /app/config
+              name: dynamic-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vdl/values.yaml
+++ b/charts/vdl/values.yaml
@@ -104,16 +104,18 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: Always
 
-securityContext: {}
+securityContext:
   # capabilities:
   #   drop:
   #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
 
 serviceN2n:
   type: LoadBalancer

--- a/charts/vdl/values.yaml
+++ b/charts/vdl/values.yaml
@@ -7,6 +7,21 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  logging:
+    repository: ghcr.io/rosemanlabs/grafana/alloy
+    tag: v1.2.1
+  vpn:
+    repository: ghcr.io/rosemanlabs/openvpn-client
+    tag: 4.0.0
+  alpine:
+    repository: ghcr.io/rosemanlabs/images/alpine
+    tag: 3.20.3
+  alpineJq:
+    repository: ghcr.io/rosemanlabs/images/apteno/alpine-jq
+    tag: 2024-09-15
+  health:
+    repository: ghcr.io/rosemanlabs/engine-healthcontainer
+    tag: v0.1.1
 imageCredentials:
   name: creds-pull
   registry: ghcr.io/rosemanlabs
@@ -16,8 +31,6 @@ imageCredentials:
 
 healthContainer:
   enabled: false
-  repository: ghcr.io/rosemanlabs/engine-healthcontainer
-  tag: "v0.1.1"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/scripts/create_local_package.sh
+++ b/scripts/create_local_package.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 cd ../charts
 set -x
-helm package vdl
+helm package --dependency-update vdl


### PR DESCRIPTION
- This PR supports rootless mode by means of an init container that sets permissions to user 1000:1000. This logic should be replicated in the Terraform code. This logic should be forward-compatible in case older releases are deployed, since the root user can access files owned by 1000:1000 just fine.
- This PR includes a bugfix for running the Helm-chart without logging enabled.