### PR TITLE
Make alloy service account conditional

### DIFF
--- a/charts/vdl/templates/statefulset.yaml
+++ b/charts/vdl/templates/statefulset.yaml
@@ -58,7 +58,11 @@ spec:
     spec:
       imagePullSecrets:
       - name: {{ .Values.imageCredentials.name }}
-      serviceAccountName: "vdl-alloy-{{- .Values.core.nodeNr }}" #{{ include "vdl.serviceAccountName" . }}
+      {{ if .Values.loggingEnabled }}
+      serviceAccountName: "vdl-alloy-{{- .Values.core.nodeNr }}" 
+      {{ else }}
+      serviceAccountName: {{ include "vdl.serviceAccountName" . }}
+      {{ end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:


### PR DESCRIPTION
If logging is not deployed with the helm chart we do not want to use the alloy service account (because that is conditionally deployed with logging).