### PR TITLE
admin: pre-commit hooks config [low prio]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/RosemanLabs/precommit-pre-commit-hooks
+    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # 4.6.0
+    hooks:
+      - id: end-of-file-fixer
+        types_or: [python, shell, yaml]
+      - id: trailing-whitespace
+        types_or: [python, shell, yaml]

--- a/README.md
+++ b/README.md
@@ -192,3 +192,7 @@ The docker image recognizes the following parameters. Not all of these values ca
 | NODE_HEARTBEAT_TIMEOUT_DELTA |                                                                                                               |
 | NODE_LOG_LEVEL               | Sets the log level \[debug etc.\]                                                                             |
 | NODE_AUX_FLAGS               | utility flag to add any flags not covered by the above                                                        |
+
+# Contributions
+
+Before committing, please install `pre-commit` on your system and run `pre-commit install` in your local repository copy.


### PR DESCRIPTION
Adds simple pre-commit hooks.

Unfortunately, yaml linting is not an option, since the linter I tested doesn't work well with Helm's go templating.